### PR TITLE
Adjust translations so sprites render. Clear to black.

### DIFF
--- a/examples/pong_tutorial_02/main.rs
+++ b/examples/pong_tutorial_02/main.rs
@@ -4,9 +4,7 @@ mod pong;
 
 use crate::pong::Pong;
 use amethyst::{
-    core::{
-        transform::{TransformBundle},
-    },
+    core::transform::TransformBundle,
     prelude::*,
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
@@ -35,7 +33,7 @@ fn main() -> amethyst::Result<()> {
                 // drawing on it
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([1.0, 0.0, 0.0, 1.0]),
+                        .with_clear([0.0, 0.0, 0.0, 1.0]),
                 )
                 // RenderFlat2D plugin is used to render entities with `SpriteRender` component.
                 .with_plugin(RenderFlat2D::default()),

--- a/examples/pong_tutorial_02/pong.rs
+++ b/examples/pong_tutorial_02/pong.rs
@@ -1,8 +1,6 @@
 use amethyst::{
     assets::{AssetStorage, Handle, Loader},
-    core::{
-        transform::{LocalToWorld, Translation},
-    },
+    core::transform::{LocalToWorld, Translation},
     prelude::*,
     renderer::{Camera, ImageFormat, SpriteRender, SpriteSheet, SpriteSheetFormat, Texture},
 };
@@ -61,7 +59,6 @@ fn load_sprite_sheet(resources: &mut Resources) -> Handle<SpriteSheet> {
             .get::<Loader>()
             .expect("Could not get Loader resource");
 
-
         let texture_storage = resources.get::<AssetStorage<Texture>>().unwrap();
         loader.load(
             "texture/pong_spritesheet.png",
@@ -85,8 +82,8 @@ fn load_sprite_sheet(resources: &mut Resources) -> Handle<SpriteSheet> {
 /// Initialise the camera.
 fn initialise_camera(world: &mut World) {
     // Setup camera in a way that our screen covers whole arena and (0, 0) is in the bottom left.
-    let translation = Translation::new(ARENA_WIDTH * 0.5, ARENA_HEIGHT * 0.5, 1.0);
-    
+    let translation = Translation::new(-ARENA_WIDTH * 0.5, -ARENA_HEIGHT * 0.5, 0.0);
+
     world.insert(
         (),
         vec![(
@@ -99,11 +96,10 @@ fn initialise_camera(world: &mut World) {
 
 /// Initialises one paddle on the left, and one paddle on the right.
 fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) {
-
     // Correctly position the paddles.
     let y = ARENA_HEIGHT / 2.0;
-    let left_translation = Translation::new(PADDLE_WIDTH * 0.5, y, 0.0);
-    let right_translation = Translation::new(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
+    let left_translation = Translation::new(PADDLE_WIDTH * 0.5, y, -1.0);
+    let right_translation = Translation::new(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, -1.0);
 
     // Assign the sprites for the paddles
     let sprite_render = SpriteRender {


### PR DESCRIPTION
Through a combination of trial and error and reading† [amethyst_rendy/src/camera.rs](https://github.com/amethyst/amethyst/blob/0d3d4730504f205b6edbbccdeade94ae903f0795/amethyst_rendy/src/camera.rs#L625-L641)  I discovered two adjustments that would cause paddles to start rendering.

1. The camera needed to be shifted in the negative x and y directions instead of positive.
2. The paddle sprites need to have z values in the range `(-z_far, -z_near]` (which from [camera.rs](https://github.com/amethyst/amethyst/blob/0d3d4730504f205b6edbbccdeade94ae903f0795/amethyst_rendy/src/camera.rs#L638) I see maps to `(-2000.0, -0.1]` in the `legion_v2` branch but `(-2000.0, -0.125]` in the current `master` branch) AND the camera z value need to be in the range `(-1.0 + z_near, 1.0 - z_near]`, which means `(-0.9, 0.9]` in this branch.  So I chose `-1.0` for the sprite z values and `0.0` for the camera z value. I don't know yet where these bounds are checked nor why they break things -- I stumbled onto the behavior through an educated guess that clipping planes might be an issue here (lucky guess) and doing some trial-and-error with +/- versions of `z_near`.  This value bound seems absolute according to my testing (not relative to z position), which makes sense in the case of the sprites (in my experience orthographic camera depth location is ignored, and the clipping planes are set to absolute values).  **Why adjusting the value of camera z to any value outside of `(-1.0 + z_near, 1.0 - z_near]` breaks sprite rendering is surprising to me--I would have expected the camera z value to either be ignored entirely, or be required to be on one side of the near/far z settings.  If someone could help me understand why this behaves this way, I would be most grateful. ❤️** Otherwise, I'll hopefully find the relevant code and figure it out someday.

I set the screen to black as well.

The rest of the changes are just `rustfmt` (because my IDE runs it on every save).



† Update: _I did more research since I wrote the commit message_.
†† Update 2: _And upon even more research, I found lower bounds that I didn't include in my original writeup._
††† Update 3: I ended up finding a different fix, which though longer code-wise is more understandable...I think. See https://github.com/jlowry/amethyst/pull/2