### PR TITLE
Fix rendering sprites in a different way.

### DIFF
--- a/examples/pong_tutorial_02/main.rs
+++ b/examples/pong_tutorial_02/main.rs
@@ -4,9 +4,7 @@ mod pong;
 
 use crate::pong::Pong;
 use amethyst::{
-    core::{
-        transform::{TransformBundle},
-    },
+    core::transform::TransformBundle,
     prelude::*,
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
@@ -35,7 +33,7 @@ fn main() -> amethyst::Result<()> {
                 // drawing on it
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([1.0, 0.0, 0.0, 1.0]),
+                        .with_clear([0.0, 0.0, 0.0, 1.0]),
                 )
                 // RenderFlat2D plugin is used to render entities with `SpriteRender` component.
                 .with_plugin(RenderFlat2D::default()),

--- a/examples/pong_tutorial_02/pong.rs
+++ b/examples/pong_tutorial_02/pong.rs
@@ -84,39 +84,17 @@ fn load_sprite_sheet(resources: &mut Resources) -> Handle<SpriteSheet> {
 
 /// Initialise the camera.
 fn initialise_camera(world: &mut World) {
-    // Setup camera in a way that our screen covers whole arena and (0, 0) is in the bottom left.
-    let camera = Camera::from(Projection::orthographic(
-        0.0,
-        ARENA_WIDTH,
-        -ARENA_HEIGHT, // Dunno why this works.  See commented section below.
-        0.0, // Ditto.
-        0.0,
-        20.0,
-    ));
+    let translation = Translation::new(ARENA_WIDTH * 0.5, ARENA_HEIGHT * 0.5, 1.0);
 
-    // WHY DOESN'T THE CODE BELOW WORK?
-    // - Using 0.0 for bottom and ARENA_HEIGHT for top seems like it ought to be the thing to do.
-    // - And -z is the far direction, so -20.0 for the far plane seems right as well.
-    // - But doing either or both of the above results in no sprite rendering that I can see.
-    //
-    // let camera = Camera::from(Projection::orthographic(
-    //     0.0,
-    //     ARENA_WIDTH,
-    //     0.0,
-    //     ARENA_HEIGHT,
-    //     0.0,
-    //     -20.0,
-    // ));
-
-    world.insert((), vec![(LocalToWorld::identity(), camera)]);
+    world.insert((), vec![(LocalToWorld::identity(), Camera::standard_2d(ARENA_WIDTH, ARENA_HEIGHT), translation)]);
 }
 
 /// Initialises one paddle on the left, and one paddle on the right.
 fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) {
     // Correctly position the paddles.
     let y = ARENA_HEIGHT / 2.0;
-    let left_translation = Translation::new(PADDLE_WIDTH * 0.5, y, -1.0);
-    let right_translation = Translation::new(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, -1.0);
+    let left_translation = Translation::new(PADDLE_WIDTH * 0.5, y, 0.0);
+    let right_translation = Translation::new(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
     let sprite_render = SpriteRender {


### PR DESCRIPTION
This approach goes directly to creating an orthographic camera with the desired projection.  Perhaps it better illustrates either the bug within Projection::orthographic() or my misunderstanding of how it is supposed to work.

I set the screen to black as well. The rest of the changes are just `rustfmt`.

Compare to the initial attempt in https://github.com/jlowry/amethyst/pull/1

/cc @jaynus @valkum Maybe you can help us (or at least me) understand why this works this way and whether this is a bug since you seem to have written and tested all the `camera.rs` code in https://github.com/amethyst/amethyst/pull/1628
